### PR TITLE
Clean up gene set dictionary in est_spectra

### DIFF
--- a/spectra/spectra.py
+++ b/spectra/spectra.py
@@ -1138,7 +1138,7 @@ def get_factor_celltypes(adata, obs_key, cellscore):
 
 
 def est_spectra(adata, gene_set_dictionary, L = None,use_highly_variable = True, cell_type_key = None, use_weights = True, lam = 0.008, delta=0.001,kappa = None, rho = 0.05, use_cell_types = True, n_top_vals = 50, 
-filter_sets = True, label_factors=True, clean_gs = True, min_gs_num = 5, overlap_threshold= 0.2, **kwargs):
+filter_sets = True, label_factors=True, clean_gs = True, min_gs_num = 3, overlap_threshold= 0.2, **kwargs):
     """ 
     
     Parameters

--- a/spectra/spectra.py
+++ b/spectra/spectra.py
@@ -1180,9 +1180,9 @@ filter_sets = True, label_factors=True, clean_gs = True, min_gs_num = 3, overlap
             whether to label the factors by their cell type specificity and their overlap coefficient with the input marker genes
         clean_gs : bool
             if True cleans up the gene set dictionary to:
-                1. to contain only genes contained in the adata. 
-                2. checks that annotations dictionary cell type keys and adata cell types are identical.
-    Checks that all gene sets in annotations dictionary contain >2 genes after filtering.
+                1. checks that annotations dictionary cell type keys and adata cell types are identical.
+                2. to contain only genes contained in the adata
+                3. to contain only gene sets greater length min_gs_num
         min_gs_num : int
             only use if clean_gs True, minimum number of genes per gene set expressed in adata, other gene sets will be filtered out
         overlap_threshold: float

--- a/spectra/spectra.py
+++ b/spectra/spectra.py
@@ -1138,7 +1138,7 @@ def get_factor_celltypes(adata, obs_key, cellscore):
 
 
 def est_spectra(adata, gene_set_dictionary, L = None,use_highly_variable = True, cell_type_key = None, use_weights = True, lam = 0.008, delta=0.001,kappa = None, rho = 0.05, use_cell_types = True, n_top_vals = 50, 
-filter_sets = True, label_factors=True, clean_gs = True, min_gs_num = 3, overlap_threshold= 0.2, **kwargs):
+filter_sets = True, label_factors=True, clean_gs = True, min_gs_num = 5, overlap_threshold= 0.2, **kwargs):
     """ 
     
     Parameters

--- a/spectra/spectra.py
+++ b/spectra/spectra.py
@@ -1138,7 +1138,7 @@ def get_factor_celltypes(adata, obs_key, cellscore):
 
 
 def est_spectra(adata, gene_set_dictionary, L = None,use_highly_variable = True, cell_type_key = None, use_weights = True, lam = 0.008, delta=0.001,kappa = None, rho = 0.05, use_cell_types = True, n_top_vals = 50, 
-filter_sets = True, label_factors=True, overlap_threshold= 0.2, **kwargs):
+filter_sets = True, label_factors=True, clean_gs = True, min_gs_num = 3, overlap_threshold= 0.2, **kwargs):
     """ 
     
     Parameters
@@ -1178,6 +1178,13 @@ filter_sets = True, label_factors=True, overlap_threshold= 0.2, **kwargs):
             whether to filter the gene sets based on coherence
         label_factors : bool
             whether to label the factors by their cell type specificity and their overlap coefficient with the input marker genes
+        clean_gs : bool
+            if True cleans up the gene set dictionary to:
+                1. to contain only genes contained in the adata. 
+                2. checks that annotations dictionary cell type keys and adata cell types are identical.
+    Checks that all gene sets in annotations dictionary contain >2 genes after filtering.
+        min_gs_num : int
+            only use if clean_gs True, minimum number of genes per gene set expressed in adata, other gene sets will be filtered out
         overlap_threshold: float
             minimum overlap coefficient to assign an input gene set label to a factor
 
@@ -1192,7 +1199,10 @@ filter_sets = True, label_factors=True, overlap_threshold= 0.2, **kwargs):
     
     """
     
-
+    #filter gene set dictionary
+    if clean_gs:
+        gene_set_dictionary = spectra_util.check_gene_set_dictionary(adata, gene_set_dictionary, obs_key=cell_type_key,global_key='global', return_dict = True,min_len=min_gs_num)
+    
     if L == None:
         init_flag = True
         if use_cell_types:

--- a/spectra/spectra.py
+++ b/spectra/spectra.py
@@ -1201,7 +1201,7 @@ filter_sets = True, label_factors=True, clean_gs = True, min_gs_num = 3, overlap
     
     #filter gene set dictionary
     if clean_gs:
-        gene_set_dictionary = spectra_util.check_gene_set_dictionary(adata, gene_set_dictionary, obs_key=cell_type_key,global_key='global', return_dict = True,min_len=min_gs_num)
+        gene_set_dictionary = spectra_util.check_gene_set_dictionary(adata, gene_set_dictionary, obs_key=cell_type_key,global_key='global', return_dict = True, min_len=min_gs_num)
     
     if L == None:
         init_flag = True

--- a/spectra/spectra_util.py
+++ b/spectra/spectra_util.py
@@ -86,8 +86,9 @@ def check_gene_set_dictionary(adata, annotations, obs_key='cell_type_annotations
         annotations_new[k] = {}
         for k2,v2 in v.items():
             gs= [x for x in v2 if x in adata.var_names]
-            if len(v2)<min_len:
-                print('removing gene set',k2,'for cell type',k,'which is of length',len(v2),'minimum length is',min_len)
+            if len(gs)<min_len:
+                print('removing gene set',k2,'for cell type',k,'which is of length',len(v2),len(gs),'genes are found in the data.',
+                      'minimum length is',min_len)
             else:
                 annotations_new[k][k2] = gs
             

--- a/spectra/spectra_util.py
+++ b/spectra/spectra_util.py
@@ -261,56 +261,6 @@ def get_factor_celltypes(adata, obs_key, cellscore_obsm_key = 'SPECTRA_cell_scor
     return factors_inv
 
 
-def check_gene_set_dictionary(adata, annotations, obs_key='cell_type_annotations',global_key='global', return_dict = True):
-    '''
-    Filters annotations dictionary contains only genes contained in the adata. 
-    Checks that annotations dictionary cell type keys and adata cell types are identical.
-    Checks that all gene sets in annotations dictionary contain >2 genes after filtering.
-    
-    adata: AnnData , data to use with Spectra
-    annotations: dict , gene set annotations dictionary to use with Spectra
-    obs_key: str , column name for cell type annotations in adata.obs
-    global_key: str , key for global gene sests in gene set annotation dictionary
-    return_dict: bool , return filtered gene set annotation dictionary
-    
-    returns: dict , filtered gene set annotation dictionary
-    
-    '''
-    #test if keys match
-    adata_labels  = list(set(adata.obs[obs_key]))+['global']#cell type labels in adata object
-    annotation_labels = list(annotations.keys())
-    matching_celltype_labels = list(set(adata_labels).intersection(annotation_labels))
-    if set(annotation_labels)==set(adata_labels):
-        print('Cell type labels in gene set annotation dictionary and AnnData object are identical')
-        dict_keys_OK = True
-    if len(annotation_labels)<len(adata_labels):
-        print('The following labels are missing in the gene set annotation dictionary:',set(adata_labels)-set(annotation_labels))
-        dict_keys_OK = False
-    if len(adata_labels)<len(annotation_labels):
-        print('The following labels are missing in the AnnData object:',set(annotation_labels)-set(adata_labels))
-        dict_keys_OK = False
-        
-    #check that gene sets in dictionary have len >2
-    Counter = 0
-    annotations_new = {}
-    for k,v in annotations.items():
-        annotations_new[k] = {}
-        for k2,v2 in v.items():
-            annotations_new[k][k2]= [x for x in v2 if x in adata.var_names]
-            length = len(v2)
-            if length<3:
-                print('gene set',k2,'for cell type',k,'is of length',length)
-                Counter = Counter+1
-            
-    if Counter > 0:
-        print(Counter,'gene sets are too small. Gene sets must contain at least 3 genes')
-    elif Counter == 0 and dict_keys_OK:
-        print('Your gene set annotation dictionary is correctly formatted.')
-    if return_dict:
-        return annotations_new
-
-
-
 #importance and information score functions 
 import torch 
 

--- a/spectra/spectra_util.py
+++ b/spectra/spectra_util.py
@@ -54,7 +54,6 @@ def check_gene_set_dictionary(adata, annotations, obs_key='cell_type_annotations
     Filters annotations dictionary to contain only genes contained in the adata. 
     Checks that annotations dictionary cell type keys and adata cell types are identical.
     Checks that all gene sets in annotations dictionary contain >2 genes after filtering.
-    if (len(adata_labels)<len(annotation_labels)) | (set(annotation_labels) != set(adata_labels)):
 
     
     adata: AnnData , data to use with Spectra
@@ -74,8 +73,8 @@ def check_gene_set_dictionary(adata, annotations, obs_key='cell_type_annotations
     if set(annotation_labels)!=set(adata_labels):
         missing_adata = set(adata_labels)-set(annotation_labels)
         missing_dict = set(annotation_labels) - set(adata_labels)
-        print('The following adata labels are missing in the gene set annotation dictionary:',missing_dict)
-        print('The following gene set annotation dictionary keys are missing in the adata labels:',missing_adata)
+        raise ValueError('The following adata labels are missing in the gene set annotation dictionary:',missing_dict,
+                        'The following gene set annotation dictionary keys are missing in the adata labels:',missing_adata)
         dict_keys_OK = False
     else:
         print('Cell type labels in gene set annotation dictionary and AnnData object are identical')


### PR DESCRIPTION
Added two new parameters in `est_spectra` `clean_gs = True` and `min_gs_num = 3` . If clean_gs is True est_spectra will clean up the gene set dictionary to:

1. check that annotations dictionary cell type keys and adata cell types are identical.
2. to contain only genes contained in the adata
3. to contain only gene sets greater length min_gs_num

Fixes:
`ZeroDivisionError: float division by zero` in `est_spectra`, `comput_init_scores`, `mimno_coherence_2011`